### PR TITLE
환경변수의 사용

### DIFF
--- a/src/main/java/com/example/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/example/projectboard/domain/UserAccount.java
@@ -40,7 +40,7 @@ public class UserAccount extends AuditingFields {
     }
 
     public static UserAccount of(String userId, String userPassword, String email, String nickname, String memo) {
-        return new UserAccount(userId, userPassword, email, nickname, memo, null);
+        return UserAccount.of(userId, userPassword, email, nickname, memo, null);
     }
     public static UserAccount of(String userId, String userPassword, String email, String nickname, String memo, String createdBy) {
         return new UserAccount(userId, userPassword, email, nickname, memo, createdBy);

--- a/src/main/java/com/example/projectboard/dto/security/BoardPrincipal.java
+++ b/src/main/java/com/example/projectboard/dto/security/BoardPrincipal.java
@@ -23,7 +23,7 @@ public record BoardPrincipal(
 ) implements UserDetails, OAuth2User {
 
     public static BoardPrincipal of(String username, String password, String email, String nickname, String memo) {
-        return of(username, password, email, nickname, memo, Map.of());
+        return BoardPrincipal.of(username, password, email, nickname, memo, Map.of());
     }
 
     public static BoardPrincipal of(String username, String password, String email, String nickname, String memo, Map<String, Object> oAuth2Attributes) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,10 +9,9 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/board
-    username: hun
-    password: 1234
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
   jpa:
     open-in-view: false
     defer-datasource-initialization: true
@@ -42,4 +41,10 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+
+---
+
+spring:
+  config.activate.on-profile: test
+  datasource.url: jdbc:h2:mem:testdb
 

--- a/src/test/java/com/example/projectboard/ProjectBoardApplicationTests.java
+++ b/src/test/java/com/example/projectboard/ProjectBoardApplicationTests.java
@@ -2,7 +2,9 @@ package com.example.projectboard;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class ProjectBoardApplicationTests {
 


### PR DESCRIPTION
application.yaml에 노출되어 있던 각종 민감정보를 변수로 치환하여 보안을 신경쓰도록 한다.
그러나.. 사실 이미 늦었다. 이전 과거 기록(커밋 노드)을 조회하면 여전히 노출된 값을 볼 수 있기 때문.
근본적인 해결을 하려면 이 저장소를 통쨰로 지우고 새로 올리는 수 밖에 없을 것 같다.
일단 공부를 하는 의미는 있으므로 이 pr을 적용한다.